### PR TITLE
Manual edits and explicit solvent minimizations

### DIFF
--- a/refinement_tools/README.md
+++ b/refinement_tools/README.md
@@ -1,0 +1,44 @@
+## Large-scale kinase structure preparation
+
+#### Initial preparation with Schrodinger
+* Kinase-inhibitor complexes were retrieved using `PDBFinder.py`.
+* Retrieved structures automatically prepared in Schrodinger's Maestro using
+`protprep.py`. 
+    * `protprep.py` modelled missing protein loops and protonates the inhibitor
+    using Schroginger's 'Epic'. Schrodinger defaults used throughout [CHECK!].
+    * The structures created from this procedure are named with the 
+     convention `XXXX-fixed.pdb`, where `XXXX` is the PDB code.
+   
+#### Refinement with OpenMM
+* Following visual inspection and preliminary simulations, the following
+ `XXXX-fixed.pdb` structures were manually edited to create `XXXX-manual.pdb`:
+    * Removed duplicate inhibitors from 4G5J such that only one inhibitor is present in the binding site
+    * Removed extra copy of the inhibitor from 3ZOS such that only one inhibitor is present in the binding site
+    * Renamed duplicate hydrogen atom names (H11 and H12 --> H111 and H112) of P06 in 3CJG
+    * Structure A was taken of multiply resolved residue CSO in 3CJG
+    * Renamed duplicate hydrogen name (H11 --> H111) of LEV in 3WZD
+    * Renamed duplicate hydrogen name (H11 --> H111) of FMM in 1XKK
+    * Removed odd spacing in atom names 'H9 1' and 'H9 1' in P06 in 5CSW
+    * Removed odd spacing in of atom names 'H9 1' and 'H9 1' in P06 in 5HIE
+    * Removed odd spacing in of atom names 'H9 1' and 'H9 1' in P06 in 4XV2 
+    * Removed chain B from 4XV2
+    * Removed ions ACT and CA from 2EUF
+* `XXXX-fixed.pdb` or `XXXX-manual.pdb` structures were minimized with `OpenMM`
+in explicit solvent using `minimize_explicit_solvent.py`. Details can be found
+in that script. Briefly:
+    * 4G5P, 4WKQ, 4XE0, 4ZAU had missing loops longer than 20 residues, so were ommited
+    * Small organic molecules, such as DMSO, were automatically deleted
+    * The `amber99sbildn`, `gaff`, and `TIP3P` forcefields were used
+* The minimized structures are located in the `explicit_water_minimized/` directories.
+
+The following structures have been ommitied from refinement with
+`OpenMM` due to tricky structures, which do not work with `MCCE`:
+* 4AN2 and 4LMN have cobimetinib bound with ATP and a metal ion
+* 3CJG has (presumably) post translation modifications to protein without `CONECT` records
+
+Structure `Imatinib-BCR-ABL/fixed/3PYY-fixed.pdb` has an activating cofactor bound, so may also be 
+inappropriate with `MCCE`.
+
+##### Notes
+* The first attempt to refine the structures with `OpenMM` was made using `old_vacuum_refinement.ipynb`. Minimizations
+were performed in vacuum, and no effort was made to fix the simulations that failed. The results of these runs are located in the `minimized/` directories.

--- a/refinement_tools/README.md
+++ b/refinement_tools/README.md
@@ -29,9 +29,9 @@ in that script. Briefly:
     * 4G5P, 4WKQ, 4XE0, 4ZAU had missing loops longer than 20 residues, so were ommited
     * Small organic molecules, such as DMSO, were automatically deleted
     * The `amber99sbildn`, `gaff`, and `TIP3P` forcefields were used
-* The minimized structures are located in the `explicit_water_minimized/` directories.
+* The minimized structures are located in the `pdbs/*/explicit_water_minimized/` directories.
 
-The following structures have been ommitied from refinement with
+The following structures have been omitted from refinement with
 `OpenMM` due to tricky structures, which do not work with `MCCE`:
 * 4AN2 and 4LMN have cobimetinib bound with ATP and a metal ion
 * 3CJG has (presumably) post translation modifications to protein without `CONECT` records

--- a/refinement_tools/minimize_explicit_solvent.py
+++ b/refinement_tools/minimize_explicit_solvent.py
@@ -1,0 +1,163 @@
+from simtk.openmm.app import *
+from simtk.openmm import *
+from simtk.unit import *
+from openmoltools.forcefield_generators import gaffTemplateGenerator
+from glob import glob
+import os
+
+#------Functions used to clean and minimizing with openmm------#
+def discard_organic(model, verbose=True):
+    """
+    Return an OpenMM modeller object that doesn't contain small organic molecules from the mother liquor
+
+    Parameter
+    ---------
+    model: simtk.openmm.app.modeller.Modeller
+        The modeller object with the PDB file of interest
+
+    Returns
+    -------
+    model: simtk.openmm.app.modeller.Modeller
+        The same object as the input with certain residues discarded
+    """
+    unwanted = ['DTT', 'EDO', 'GOL', 'SO4', 'PO4', 'DMS', 'ACT']
+    for junk in unwanted:
+        atms = [atm for atm in model.topology.atoms() if atm.residue.name == junk]
+        if len(atms) > 0:
+            if verbose == True: print('Deleting {0} from topology'.format(junk))
+            model.delete(atms)
+    return model
+
+def get_upper_location(pdb_location, back=2):
+    """
+    Get the path of the directory that's up from the path specified from pdb_location.
+    """
+    path = pdb_location.split('/')[0:-back]
+    upper_path = ''
+    for location in path:
+        upper_path += location + '/'
+    return upper_path
+
+def openmm_clean(pdb_filename, pdbname, out_folder='minimized', gpu=False, solvate=False):
+    """
+    Minimize a supplied system with openmm. Can handle small molecules as long as CONECT
+    records are supplied.
+    """
+    # Initialize forcefield with small molecule capabilities
+    forcefield = ForceField('gaff.xml','tip3p.xml','amber99sbildn.xml')
+    forcefield.registerTemplateGenerator(gaffTemplateGenerator)
+
+    # Use modeller to remove unwanted residues
+    pdb = PDBFile(pdb_filename)
+    model = Modeller(pdb.topology, pdb.positions)
+
+    # Remove unwanted molecules
+    model = discard_organic(model, verbose=False)
+
+    # Add waters in a cubic box
+    if solvate == True:
+        model.addSolvent(forcefield, padding=1.0*nanometers)
+
+    # Create the system with a cheap electrostatic cutoff
+    system = forcefield.createSystem(model.topology, nonbondedMethod=CutoffNonPeriodic)
+
+    # Minimize system with a placeholder integrator
+    integrator = VerletIntegrator(0.001*picoseconds)
+    if gpu == True:
+        platform = Platform.getPlatformByName('OpenCL')
+        properties = {'OpenCLPrecision': 'mixed'}
+        simulation = Simulation(model.topology, system, integrator, platform, properties)
+    else:
+        simulation = Simulation(model.topology, system, integrator)
+    simulation.context.setPositions(model.positions)
+    simulation.minimizeEnergy()
+
+    # Print PDB
+    positions = simulation.context.getState(getPositions=True).getPositions()
+    out_directory = get_upper_location(pdb_filename)
+    try:
+        os.mkdir(out_directory + out_folder)
+    except OSError:
+        pass
+    PDBFile.writeFile(simulation.topology, positions, open(out_directory + out_folder + '/' + pdbname + '-minimized.pdb', 'w'))
+
+if __name__ == "__main__":
+
+    #------Generating the list of useable structures------#
+
+    # Structures that will be omited for now due to tricky structure :
+    # - 4AN2 and 4LMN have cobimetinib bound with ATP and an ion
+    # - 3CJG has (presumably) post translation modifications to protein without CONECT records
+    omit_pdbs = ['4AN2', '4LMN', '3CJG']
+
+    # Structures that needed manual refinement, and are called XXXX-manual.pdb
+    manual_edits = ['4G5J', '4XV2', '3ZOS', '3CJG', '3WZD', '1XKK', '5CSW', '5HIE', ' 2EUF']
+
+    # Pre-assigment
+    complete_pdbs = []     # The X-ray structures that are complete, with no modelled in loops
+    missing_pdbs = []      # The X-ray structures that had missing loops longer than 20 residues, and were not modelled
+    refine_pdbs = []       # All the structures that will be further refined with OpenMM
+    refine_pdbs_location = [] # The relative location of the protein-ligand files that will be minimized
+
+    # Looping through all the directories and locating the PDB structures that will be minimized with openmm
+    for folder in glob('../pdbs/*'):
+        for subfolder in glob(folder + '/fixed/*'):
+            filename = subfolder.split('/')[-1]
+            if filename.split('.')[-1] == 'pdb':
+                pdb_code = filename.split('.')[0].split('-')[0]
+                if pdb_code not in omit_pdbs:
+                    logfile = folder + '/fixed/' +  pdb_code + '-fixed' + '/' + pdb_code.lower() + '-missing-loops.log'
+                    logfile = open(logfile, 'r').read()
+                    finder = logfile.find('Found loops without PDB coordinates')
+                    if finder == -1:
+                        # If no loops have been modeled, the structure was complete from the start!
+                        complete_pdbs.append(pdb_code)
+                    finder = logfile.find('is too long, skipping')
+                    if finder != -1:
+                        # Disregard structurs whose missing loops were too long to model in
+                        missing_pdbs.append(pdb_code)
+                    else:
+                        refine_pdbs.append(pdb_code)
+                        refine_pdbs_location.append(folder + '/fixed/' + filename)
+
+    # Now removing the duplicate structures that have arisen due to the manaully edited PDB structures.
+    index = 0
+    for filename in refine_pdbs_location:
+        for pdb in manual_edits:
+            if  filename.split('/')[-1] == pdb + '-fixed.pdb':
+                refine_pdbs.pop(index)
+                refine_pdbs_location.pop(index)
+        index += 1
+
+    import logging
+    logging.basicConfig(filename='explicit_solvent_minimization.log',level=logging.DEBUG)
+    logging.captureWarnings(True)
+
+    #------Cleaning and minimizing with openmm------#
+    # Pre-assignment
+    broken_pdbs = []
+    minimized_pdbs = []
+    minimized_files = []
+
+    # Running through refined structures and seeing if they work
+    for filename, pdb in zip(refine_pdbs_location, refine_pdbs):
+        logging.info('Refining structure {0}'.format(pdb))
+        try:
+            openmm_clean(filename, pdb, out_folder='explicit_water_minimized', gpu=True, solvate=True)
+            minimized_pdbs.append(pdb)
+            minimized_files.append(filename)
+            logging.info('Structure {0} COMPLETED.'.format(pdb))
+            logging.info('Original file located in {0}'.format(pdb, filename))
+            logging.info('-----------------------------')
+        except Exception as detail:
+            logging.error(detail)
+            logging.info('Structure {0} BROKEN'.format(pdb))
+            logging.info('Original file located in {0}'.format(pdb, filename))
+            logging.info('-----------------------------')
+            broken_pdbs.append(filename)
+
+    with open('completed.txt', 'w') as the_file:
+        the_file.writelines(["%s\n" % item  for item in minimized_pdbs])
+
+    with open('broken.txt', 'w') as the_file:
+        the_file.writelines(["%s\n" % item  for item in broken_pdbs])

--- a/refinement_tools/old_vaccuum_refinement.ipynb
+++ b/refinement_tools/old_vaccuum_refinement.ipynb
@@ -1,0 +1,375 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from simtk.openmm.app import *\n",
+    "from simtk.openmm import *\n",
+    "from simtk.unit import *\n",
+    "from openmoltools.forcefield_generators import gaffTemplateGenerator\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Finding the structures that are useable\n",
+    "Looking at the latest fixed structures and selecting which ones to minimize with `openmm`. Structures that are inappropriate for MCCE (e.g. contain functionally important cofactors) or are omitted for now, as MCCE can only handle one small molecule at a time.\n",
+    "\n",
+    "Some notes about the selection\n",
+    "* Omiting structures with cobimetinib are omitted due to the presence of ATP and an ion in binding site\n",
+    "* Omiting 3PYY as it has an allosteric activator bound.\n",
+    "\n",
+    "Manual edits. Files `XXXX-fixed.pdb` were manually edited to make `XXXX-maunal.pdb`.\n",
+    "* Removed duplicate ligands from 4G5J\n",
+    "* Removed chain B from 4XV2.\n",
+    "* Removed extra copied of the inhibitor ligand from 3ZOS\n",
+    "* Renamed duplicate hydrogen atom names (H11 and H12 --> H111 and H112) of P06 in 3CJG\n",
+    "* Renamed duplicate hydrogen name (H11 --> H111) of LEV in 3WZD\n",
+    "* Renamed duplicate hydrogen name (H11 --> H111) of FMM in 1XKK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from glob import glob\n",
+    "\n",
+    "# Structures with important cofactors bound. \n",
+    "omit_pdbs = ['2EUF', '4AN2', '4LMN', '3PYY']\n",
+    "\n",
+    "# Structures that need manual refinement\n",
+    "manual_edits = ['4G5J', '4XV2', '3ZOS', '3CJG', '3WZD', '1XKK']   # XXXX-manual.pdb\n",
+    "\n",
+    "# For now, neglecting systems that need manual tweaking\n",
+    "omit_pdbs += manual_edits\n",
+    "\n",
+    "# Pre-assigment\n",
+    "complete_pdbs = []     # The X-ray structures that are complete, with no modelled in loops\n",
+    "missing_pdbs = []      # The X-ray structures that had missing loops longer than 20 residues, and were not modelled\n",
+    "refine_pdbs = []       # All the structures that will be further refined with OpenMM\n",
+    "refine_pdbs_location = [] # The relative location of the protein-ligand files that will be minimized\n",
+    "\n",
+    "for folder in glob('../pdbs/*'):\n",
+    "    for subfolder in glob(folder + '/fixed/*'):\n",
+    "        filename = subfolder.split('/')[-1]\n",
+    "        if filename.split('.')[-1] == 'pdb':\n",
+    "            pdb_code = filename.split('.')[0].split('-')[0]\n",
+    "            #if pdb_code in manual_edits:\n",
+    "            #    decorator = 'manual-'\n",
+    "            #else:\n",
+    "            #    decorator = ''\n",
+    "            if pdb_code not in omit_pdbs:\n",
+    "                logfile = folder + '/fixed/' +  pdb_code + '-fixed' + '/' + pdb_code.lower() + '-missing-loops.log'\n",
+    "                logfile = open(logfile, 'r').read()\n",
+    "                finder = logfile.find('Found loops without PDB coordinates')\n",
+    "                if finder == -1:\n",
+    "                    # If no loops have been modeled, the structure was complete from the start!\n",
+    "                    complete_pdbs.append(pdb_code)\n",
+    "                finder = logfile.find('is too long, skipping')\n",
+    "                if finder != -1:\n",
+    "                    # Disregard structurs whose missing loops were too long to model in\n",
+    "                    missing_pdbs.append(pdb_code)\n",
+    "                else:\n",
+    "                    refine_pdbs.append(pdb_code)\n",
+    "                    refine_pdbs_location.append(folder + '/fixed/' + filename)\n",
+    "\n",
+    "# Now removing the duplicate structures that have arison due to the manaully edited PDB structures.\n",
+    "index = 0\n",
+    "for filename in refine_pdbs_location:\n",
+    "    for pdb in manual_edits:\n",
+    "        if  filename.split('/')[-1] == pdb + '-fixed.pdb':\n",
+    "            refine_pdbs.pop(index)\n",
+    "            refine_pdbs_location.pop(index)\n",
+    "    index += 1                    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Minimizing with OpenMM\n",
+    "And in the process throwing out the structures that can't be minimized."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def discard_organic(model, verbose=True):\n",
+    "    \"\"\"\n",
+    "    Return an OpenMM modeller object that doesn't contain small organic molecules from the mother liquor\n",
+    "    \n",
+    "    Parameter\n",
+    "    ---------\n",
+    "    model: simtk.openmm.app.modeller.Modeller\n",
+    "        The modeller object with the PDB file of interest\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    model: simtk.openmm.app.modeller.Modeller\n",
+    "        The same object as the input with certain residues discarded\n",
+    "    \"\"\"\n",
+    "    unwanted = ['DTT', 'EDO', 'GOL', 'SO4', 'PO4', 'DMS']\n",
+    "    for junk in unwanted:\n",
+    "        atms = [atm for atm in model.topology.atoms() if atm.residue.name == junk]\n",
+    "        if len(atms) > 0:\n",
+    "            if verbose == True: print('Deleting {0} from topology'.format(junk))\n",
+    "            model.delete(atms)\n",
+    "    return model\n",
+    "\n",
+    "def get_upper_location(pdb_location, back=2):\n",
+    "    \"\"\"\n",
+    "    Get the path of the directory that's up from the path specified from pdb_location. \n",
+    "    \"\"\"\n",
+    "    path = pdb_location.split('/')[0:-back]\n",
+    "    upper_path = ''\n",
+    "    for location in path:\n",
+    "        upper_path += location + '/'\n",
+    "    return upper_path    \n",
+    "\n",
+    "def openmm_clean(pdb_filename, pdbname, out_folder='minimized', solvate=False):\n",
+    "    \"\"\"\n",
+    "    Minimize a supplied system with openmm. Can handle small molecules as long as CONECT \n",
+    "    records are supplied.\n",
+    "    \"\"\"\n",
+    "    # Initialize forcefield with small molecule capabilities\n",
+    "    forcefield = ForceField('gaff.xml','tip3p.xml','amber99sbildn.xml')\n",
+    "    forcefield.registerTemplateGenerator(gaffTemplateGenerator)\n",
+    "    \n",
+    "    # Use modeller to remove unwanted residues\n",
+    "    pdb = PDBFile(pdb_filename)\n",
+    "    model = Modeller(pdb.topology, pdb.positions)\n",
+    "    \n",
+    "    # Remove unwanted molecules\n",
+    "    model = discard_organic(model, verbose=False)\n",
+    "    \n",
+    "    # Add waters in a cubic box\n",
+    "    if solvate == True:\n",
+    "        model.addSolvent(forcefield, padding=1.0*nanometers)\n",
+    "    \n",
+    "    # Create the system with a cheap electrostatic cutoff\n",
+    "    system = forcefield.createSystem(model.topology, nonbondedMethod=CutoffNonPeriodic)\n",
+    "    \n",
+    "    # Minimize system with a placeholder integrator\n",
+    "    integrator = VerletIntegrator(0.001*picoseconds)\n",
+    "    simulation = Simulation(model.topology, system, integrator)\n",
+    "    simulation.context.setPositions(model.positions)\n",
+    "    simulation.minimizeEnergy()\n",
+    "    \n",
+    "    # Print PDB\n",
+    "    positions = simulation.context.getState(getPositions=True).getPositions()\n",
+    "    out_directory = get_upper_location(pdb_filename)\n",
+    "    try:\n",
+    "        os.mkdir(out_directory + out_folder)\n",
+    "    except OSError:\n",
+    "        pass\n",
+    "    PDBFile.writeFile(simulation.topology, positions, open(out_directory + out_folder + pdbname + '-minimized.pdb', 'w'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "No module named logger",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-4578946333af>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mlogger\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m: No module named logger"
+     ]
+    }
+   ],
+   "source": [
+    "import logger"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings('error')\n",
+    "\n",
+    "import logging\n",
+    "logging.basicConfig(filename='explicit_solvent_minimization.log',level=logging.DEBUG)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Pre-assigment\n",
+    "broken_pdbs = []\n",
+    "minimized_pdbs = []\n",
+    "minimized_files = []\n",
+    "\n",
+    "# Running through refined structures and seeing if they work\n",
+    "for filename, pdb in zip(refine_pdbs_location, refine_pdbs):\n",
+    "    #print 'Running with {0}'.format(pdb)\n",
+    "    try:\n",
+    "        openmm_clean(filename, pdb)\n",
+    "        minimized_pdbs.append(pdb)\n",
+    "        minimized_files.append(filename)\n",
+    "    except Exception as detail:\n",
+    "        #print detail\n",
+    "        broken_pdbs.append(filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This files incurred further errors with `openmm`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "../pdbs/Dabrafenib-BRAF/fixed/4XV2-fixed.pdb\n",
+      "../pdbs/Dabrafenib-BRAF/fixed/5CSW-fixed.pdb\n",
+      "../pdbs/Dabrafenib-BRAF/fixed/5HIE-fixed.pdb\n",
+      "../pdbs/Lapatinib-EGFR/fixed/1XKK-fixed.pdb\n",
+      "../pdbs/Lenvatinib-VEGFR1/fixed/3WZD-fixed.pdb\n",
+      "../pdbs/Pazopanib-VEGFR1/fixed/3CJG-fixed.pdb\n"
+     ]
+    }
+   ],
+   "source": [
+    "for filename in broken_pdbs:\n",
+    "    print filename "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following files are passed the current tests, but will need further inspection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "../pdbs/Alectinib-ALK/fixed/3AOX-fixed.pdb\n",
+      "../pdbs/Axitinib-VEGFR1/fixed/4AG8-fixed.pdb\n",
+      "../pdbs/Axitinib-VEGFR1/fixed/4AGC-fixed.pdb\n",
+      "../pdbs/Bosutinib-BCR-ABL/fixed/3UE4-fixed.pdb\n",
+      "../pdbs/Ceritinib-ALK/fixed/4MKC-fixed.pdb\n",
+      "../pdbs/Crizotinib-ALK/fixed/2XP2-fixed.pdb\n",
+      "../pdbs/Crizotinib-ALK/fixed/2YFX-fixed.pdb\n",
+      "../pdbs/Crizotinib-ALK/fixed/4ANQ-fixed.pdb\n",
+      "../pdbs/Crizotinib-ALK/fixed/4ANS-fixed.pdb\n",
+      "../pdbs/Crizotinib-ALK/fixed/5AAA-fixed.pdb\n",
+      "../pdbs/Crizotinib-ALK/fixed/5AAB-fixed.pdb\n",
+      "../pdbs/Crizotinib-ALK/fixed/5AAC-fixed.pdb\n",
+      "../pdbs/Crizotinib-MET/fixed/2WGJ-fixed.pdb\n",
+      "../pdbs/Dasatinib-BCR-ABL/fixed/2GQG-fixed.pdb\n",
+      "../pdbs/Dasatinib-BCR-ABL/fixed/4XEY-fixed.pdb\n",
+      "../pdbs/Erlotinib-EGFR/fixed/1M17-fixed.pdb\n",
+      "../pdbs/Erlotinib-EGFR/fixed/4HJO-fixed.pdb\n",
+      "../pdbs/Gefitinib-EGFR/fixed/2ITO-fixed.pdb\n",
+      "../pdbs/Gefitinib-EGFR/fixed/2ITY-fixed.pdb\n",
+      "../pdbs/Gefitinib-EGFR/fixed/2ITZ-fixed.pdb\n",
+      "../pdbs/Gefitinib-EGFR/fixed/3UG2-fixed.pdb\n",
+      "../pdbs/Gefitinib-EGFR/fixed/4I22-fixed.pdb\n",
+      "../pdbs/Imatinib-BCR-ABL/fixed/2HYY-fixed.pdb\n",
+      "../pdbs/Nilotinib-BCR-ABL/fixed/3CS9-fixed.pdb\n",
+      "../pdbs/Palbociclib-CDK6/fixed/5L2I-fixed.pdb\n",
+      "../pdbs/Ponatinib-DDR1/fixed/3ZOS-fixed.pdb\n",
+      "../pdbs/Regorafenib-VEGFR1/fixed/2QU5-fixed.pdb\n",
+      "../pdbs/Sorafenib-VEGFR1/fixed/3WZE-fixed.pdb\n",
+      "../pdbs/Sorafenib-VEGFR1/fixed/4ASD-fixed.pdb\n",
+      "../pdbs/Sunitinib-VEGFR1/fixed/4AGD-fixed.pdb\n",
+      "../pdbs/Tofacitinib-JAK3/fixed/3LXK-fixed.pdb\n"
+     ]
+    }
+   ],
+   "source": [
+    "for filename in minimized_files:\n",
+    "    print filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
@jchodera @steven-albanese 

Structures that have been manually edited and minimized in explicit solvent have been added, as has the script for running the cleaning and minimizations in `openmm`, and a README.

Why
---
The structures contained in all the`minimized/` directories were minimized in vacuum (with crystallographic waters present), and no attempt was made to fix the structures that failed minimization. A number of 'XXXX-fixed.pdb' structures contained mistakes and crystallographic artifacts that needed manually editing. All details of the manual edits can be found in `README.md`, which is also added to this commit.